### PR TITLE
Delete batch Selection Data on early exit

### DIFF
--- a/cadence/contracts/PrizeLinkedAccounts.cdc
+++ b/cadence/contracts/PrizeLinkedAccounts.cdc
@@ -4112,8 +4112,8 @@ access(all) contract PrizeLinkedAccounts {
         // LOTTERY DRAW OPERATIONS
         // ============================================================
 
-        /// Destroys the active round and transitions the pool into intermission.
-        /// Called from startDraw() (empty pool) and completeDraw() (no winners).
+        /// Destroys the active round and any pending batch state, transitioning the pool into intermission.
+        /// Single authoritative teardown — called from startDraw() (empty pool) and completeDraw() (all paths).
         access(self) fun enterIntermission() {
             let usedRound <- self.activeRound <- nil
             let completedRoundID = usedRound?.getRoundID() ?? 0
@@ -4213,8 +4213,6 @@ access(all) contract PrizeLinkedAccounts {
             // allocatedPrizeYield carries forward to the next round automatically.
             if self.registeredReceiverList.length == 0 {
                 let endedRoundID = (&self.activeRound as &Round?)?.getRoundID() ?? 0
-                let unusedSelectionData <- self.pendingSelectionData <- nil
-                destroy unusedSelectionData
                 emit DrawBatchStarted(
                     poolID: self.poolID,
                     endedRoundID: endedRoundID,
@@ -4412,10 +4410,6 @@ access(all) contract PrizeLinkedAccounts {
                 totalPrizeAmount: totalPrizeAmount
             )
             
-            // Consume and destroy selection data (done with it)
-            let usedSelectionData <- self.pendingSelectionData <- nil
-            destroy usedSelectionData
-            
             // Extract distribution results (winners are already selected above)
             let distributedWinners = selectionResult.winners
             let prizeAmounts = selectionResult.amounts
@@ -4536,19 +4530,7 @@ access(all) contract PrizeLinkedAccounts {
                 round: currentRound
             )
             
-            // Destroy the active round - its TWAB data has been used
-            // Store the completed round ID before destroying for intermission state queries
-            let usedRound <- self.activeRound <- nil
-            let completedRoundID = usedRound?.getRoundID() ?? 0
-            self.lastCompletedRoundID = completedRoundID
-            destroy usedRound
-            
-            // Pool is now in intermission - emit event
-            emit IntermissionStarted(
-                poolID: self.poolID,
-                completedRoundID: completedRoundID,
-                prizePoolBalance: self.allocatedPrizeYield
-            )
+            self.enterIntermission()
         }
 
         /// Starts a new round, exiting intermission (Phase 5 - optional, for explicit round control).

--- a/cadence/contracts/PrizeLinkedAccounts.cdc
+++ b/cadence/contracts/PrizeLinkedAccounts.cdc
@@ -4119,6 +4119,8 @@ access(all) contract PrizeLinkedAccounts {
             let completedRoundID = usedRound?.getRoundID() ?? 0
             self.lastCompletedRoundID = completedRoundID
             destroy usedRound
+            let unusedSelectionData <- self.pendingSelectionData <- nil
+            destroy unusedSelectionData
             emit IntermissionStarted(
                 poolID: self.poolID,
                 completedRoundID: completedRoundID,
@@ -4211,6 +4213,8 @@ access(all) contract PrizeLinkedAccounts {
             // allocatedPrizeYield carries forward to the next round automatically.
             if self.registeredReceiverList.length == 0 {
                 let endedRoundID = (&self.activeRound as &Round?)?.getRoundID() ?? 0
+                let unusedSelectionData <- self.pendingSelectionData <- nil
+                destroy unusedSelectionData
                 emit DrawBatchStarted(
                     poolID: self.poolID,
                     endedRoundID: endedRoundID,

--- a/cadence/contracts/PrizeLinkedAccounts.cdc
+++ b/cadence/contracts/PrizeLinkedAccounts.cdc
@@ -4113,7 +4113,6 @@ access(all) contract PrizeLinkedAccounts {
         // ============================================================
 
         /// Destroys the active round and any pending batch state, transitioning the pool into intermission.
-        /// Single authoritative teardown — called from startDraw() (empty pool) and completeDraw() (all paths).
         access(self) fun enterIntermission() {
             let usedRound <- self.activeRound <- nil
             let completedRoundID = usedRound?.getRoundID() ?? 0

--- a/cadence/tests/BatchDraw_test.cdc
+++ b/cadence/tests/BatchDraw_test.cdc
@@ -699,4 +699,11 @@ access(all) fun testDrawWithNoRegisteredUsers() {
     // Admin can start a new round normally after the empty draw
     startNextRound(deployer, poolID: poolID)
     Test.assertEqual(false, isInIntermission(poolID))
+
+    // Second consecutive empty draw must not panic (regression for BatchSelectionData resource leak)
+    Test.moveTime(by: 70.0)
+    startDraw(deployer, poolID: poolID)
+    Test.assertEqual(true, isInIntermission(poolID))
+    startNextRound(deployer, poolID: poolID)
+    Test.assertEqual(false, isInIntermission(poolID))
 }

--- a/cadence/tests/BatchDraw_test.cdc
+++ b/cadence/tests/BatchDraw_test.cdc
@@ -707,3 +707,86 @@ access(all) fun testDrawWithNoRegisteredUsers() {
     startNextRound(deployer, poolID: poolID)
     Test.assertEqual(false, isInIntermission(poolID))
 }
+
+access(all) fun testEmptyDrawThenNormalDraw() {
+    // Verifies that a round with no participants followed by a round with
+    // participants completes correctly and distributes prizes normally.
+    let deployer = Test.createAccount()
+    let poolID = createTestPoolWithMediumInterval()
+
+    // Round 1: no users, fund prize pool so yield accumulates
+    fundPrizePool(poolID, amount: 30.0)
+    Test.moveTime(by: 70.0)
+    startDraw(deployer, poolID: poolID)
+    Test.assertEqual(true, isInIntermission(poolID))
+
+    // Prize carries forward
+    let totalsAfterEmptyDraw = getPoolTotals(poolID)
+    let prizeAfterEmpty = totalsAfterEmptyDraw["prizeBalance"] ?? 0.0
+    Test.assert(prizeAfterEmpty >= 30.0, message: "Prize should carry forward: \(prizeAfterEmpty)")
+
+    // Round 2: add a user, run normal full draw sequence
+    startNextRound(deployer, poolID: poolID)
+
+    let user = Test.createAccount()
+    setupUserWithFundsAndCollection(user, amount: 200.0)
+    depositToPool(user, poolID: poolID, amount: 100.0)
+
+    fundPrizePool(poolID, amount: 20.0)
+    Test.moveTime(by: 70.0)
+
+    startDraw(user, poolID: poolID)
+
+    // Should be in batch processing (not immediate intermission) since there is a user
+    Test.assertEqual(false, isInIntermission(poolID))
+
+    processAllDrawBatches(user, poolID: poolID, batchSize: 1000)
+    commitBlocksForRandomness()
+    completeDraw(user, poolID: poolID)
+
+    Test.assertEqual(true, isInIntermission(poolID))
+
+    // Prize pool should be reduced (prizes distributed to the one user)
+    let totalsAfterNormalDraw = getPoolTotals(poolID)
+    let prizeAfterNormal = totalsAfterNormalDraw["prizeBalance"] ?? 0.0
+    Test.assert(prizeAfterNormal < prizeAfterEmpty + 20.0, message: "Prizes should have been distributed: \(prizeAfterNormal)")
+}
+
+access(all) fun testNormalDrawThenEmptyDraw() {
+    // Verifies that a normal draw followed by an empty draw does not corrupt
+    // state — the BatchSelectionData from the normal draw is fully cleaned up
+    // before the empty draw runs.
+    let deployer = Test.createAccount()
+    let poolID = createTestPoolWithMediumInterval()
+
+    // Round 1: normal draw with one user
+    let user = Test.createAccount()
+    setupUserWithFundsAndCollection(user, amount: 200.0)
+    depositToPool(user, poolID: poolID, amount: 100.0)
+    fundPrizePool(poolID, amount: 50.0)
+    Test.moveTime(by: 70.0)
+
+    startDraw(user, poolID: poolID)
+    processAllDrawBatches(user, poolID: poolID, batchSize: 1000)
+    commitBlocksForRandomness()
+    completeDraw(user, poolID: poolID)
+    Test.assertEqual(true, isInIntermission(poolID))
+
+    // User fully withdraws (prizes were auto-compounded so balance > 100).
+    // Query the actual asset balance and withdraw it all to reach zero shares,
+    // which unregisters the user from the pool.
+    let balanceInfo = getUserPoolBalance(user.address, poolID)
+    let fullBalance = balanceInfo["totalBalance"] ?? 0.0
+    Test.assert(fullBalance > 0.0, message: "User should have a balance after winning prizes: \(fullBalance)")
+    withdrawFromPool(user, poolID: poolID, amount: fullBalance)
+
+    // Round 2: user is unregistered — empty draw must not panic
+    startNextRound(deployer, poolID: poolID)
+    Test.moveTime(by: 70.0)
+    startDraw(deployer, poolID: poolID)
+    Test.assertEqual(true, isInIntermission(poolID))
+
+    // Can start a fresh round after the empty draw
+    startNextRound(deployer, poolID: poolID)
+    Test.assertEqual(false, isInIntermission(poolID))
+}


### PR DESCRIPTION
When we enter intermission early, we never deleted the BatchSelection Data.  Successive draws were erroring because it was expecting this information to be nil