### PR TITLE
Reduce yield-source quotes in withdraw path to fix computation-limit failures

### DIFF
--- a/cadence/contracts/FlowYieldVaultsConnectorV2.cdc
+++ b/cadence/contracts/FlowYieldVaultsConnectorV2.cdc
@@ -235,10 +235,6 @@ access(all) contract FlowYieldVaultsConnectorV2 {
                 return <- DeFiActionsUtils.getEmptyVault(self.vaultType)
             }
 
-            let available = managerRef.getYieldVaultBalance()
-            assert(available > 0.0, message: "Connector.withdrawAvailable: zero balance. requested: "
-                .concat(truncatedAmount.toString()))
-
             return <- managerRef.withdrawFromYieldVault(maxAmount: truncatedAmount)
         }
 

--- a/cadence/contracts/PrizeLinkedAccounts.cdc
+++ b/cadence/contracts/PrizeLinkedAccounts.cdc
@@ -3559,10 +3559,8 @@ access(all) contract PrizeLinkedAccounts {
                     panic("Pool is paused. No operations allowed. ReceiverID: \(receiverID), amount: \(nominalAmount)")
             }
 
-            // Process pending yield/deficit before deposit to ensure fair share price
-            if self.needsSync() {
-                self.syncWithYieldSource()
-            }
+            // Process pending yield/deficit before deposit to ensure fair share price.
+            self.syncWithYieldSource()
 
             let now = getCurrentBlock().timestamp
 
@@ -3647,10 +3645,8 @@ access(all) contract PrizeLinkedAccounts {
                     panic("Pool is paused. No operations allowed. ReceiverID: \(receiverID), amount: \(nominalAmount)")
             }
 
-            // Process pending yield/deficit before deposit to ensure fair share price
-            if self.needsSync() {
-                self.syncWithYieldSource()
-            }
+            // Process pending yield/deficit before deposit to ensure fair share price.
+            self.syncWithYieldSource()
 
             // 1. Deposit to yield source FIRST (zero-check is centralized in depositToYieldSourceFull)
             let actualReceived = self.depositToYieldSourceFull(<- from)
@@ -3732,9 +3728,17 @@ access(all) contract PrizeLinkedAccounts {
                 let _ = self.checkAndAutoRecover()
             }
             
-            // Process pending yield/deficit before withdrawal (if in normal mode)
-            if self.emergencyState == PoolEmergencyState.Normal && self.needsSync() {
-                self.syncWithYieldSource()
+            // Querying the yield source balance is expensive (strategies may quote
+            // swap routes via EVM), so fetch it once and reuse it for both the sync
+            // and the liquidity check below. Syncing only updates internal accounting
+            // and never moves funds, so the balance cannot change in between.
+            let yieldAvailable = self.config.yieldConnector.minimumAvailable()
+
+            // Process pending yield/deficit before withdrawal (if in normal mode).
+            // syncWithYieldBalance() skips differences below MINIMUM_DISTRIBUTION_THRESHOLD,
+            // which covers the previous needsSync() gate.
+            if self.emergencyState == PoolEmergencyState.Normal {
+                self.syncWithYieldBalance(yieldBalance: yieldAvailable)
             }
             
             // Validate user has sufficient balance
@@ -3753,9 +3757,6 @@ access(all) contract PrizeLinkedAccounts {
 
             // For full withdrawals, request the full balance (may be adjusted by yield source availability)
             var withdrawAmount = isFullWithdrawal ? totalBalance : amount
-
-            // Check if yield source has sufficient liquidity
-            let yieldAvailable = self.config.yieldConnector.minimumAvailable()
 
             // For full withdrawals with minor rounding mismatch, use available amount
             if isFullWithdrawal && yieldAvailable < withdrawAmount && yieldAvailable > 0.0 {
@@ -3898,7 +3899,14 @@ access(all) contract PrizeLinkedAccounts {
         /// Called automatically during deposits and withdrawals.
         /// Can also be called manually by admin.
         access(contract) fun syncWithYieldSource() {
-            let yieldBalance = self.config.yieldConnector.minimumAvailable()
+            self.syncWithYieldBalance(yieldBalance: self.config.yieldConnector.minimumAvailable())
+        }
+
+        /// Variant of syncWithYieldSource() that takes a pre-fetched yield source balance.
+        /// Querying the yield source is expensive (strategies may quote swap routes
+        /// via EVM), so callers that already hold a fresh minimumAvailable() result
+        /// pass it here instead of paying for a second query.
+        access(contract) fun syncWithYieldBalance(yieldBalance: UFix64) {
             let allocatedFunds = self.getTotalAllocatedFunds()
             
             // Calculate absolute difference
@@ -4157,9 +4165,7 @@ access(all) contract PrizeLinkedAccounts {
             // Sync with yield source to capture any pending yield before materializing prizes.
             // This ensures yield added directly to the yield source (not via deposits) is
             // properly accounted for in allocatedPrizeYield before the draw.
-            if self.needsSync() {
-                self.syncWithYieldSource()
-            }
+            self.syncWithYieldSource()
 
             let now = getCurrentBlock().timestamp
 

--- a/cadence/scripts/prize-linked-accounts/get_pool_balance_safe.cdc
+++ b/cadence/scripts/prize-linked-accounts/get_pool_balance_safe.cdc
@@ -1,0 +1,12 @@
+import "PrizeLinkedAccounts"
+
+/// Returns a user's withdrawable balance in a pool, or 0.0 if the account has no
+/// collection / is not registered. Safe to run at historical block heights where
+/// the account may not yet have set up a collection.
+access(all) fun main(address: Address, poolID: UInt64): UFix64 {
+    let col = getAccount(address).capabilities.borrow<&PrizeLinkedAccounts.PoolPositionCollection>(
+        PrizeLinkedAccounts.PoolPositionCollectionPublicPath
+    )
+    if col == nil { return 0.0 }
+    return col!.getPoolBalance(poolID: poolID).totalBalance
+}


### PR DESCRIPTION
## Problem

Users cannot withdraw from pool 1 on mainnet. Withdrawals fail with `[Error Code: 1300] evm runtime error: insufficient computation` at `gas_limit: 9999` — **the network maximum**, so nothing can be raised on the client side. Example: [`16270911…c21f8c6d`](https://www.flowscan.io/tx/162709115311c02e9d4e2108315b56475efcbfde43930b5103779789c21f8c6d).

## Root cause

`FlowYieldVaultsConnectorV2.Connector.minimumAvailable()` was designed as a cheap balance read, but under the FUSDEV strategy it is a **full multi-route swap quote** (UniswapV3 quoter dry-calls + Morpho preview, via `PMStrategiesV1.availableBalance → MultiSwapper.quoteOut`) costing **~1,100 computation units per call**. One logical withdrawal performed it **six times** before doing any work. True cost of the failing tx, measured on a mainnet fork with the limit raised: **~12,400 units** vs the 9,999 ceiling.

## Changes

| Call site | Before | After |
|---|---|---|
| `Pool.withdraw` — `needsSync()` gate | quote | removed (sync no-ops below threshold itself) |
| `Pool.withdraw` — `syncWithYieldSource()` | quote | single fetch at top of `withdraw`, passed via new `syncWithYieldBalance(yieldBalance:)` |
| `Pool.withdraw` — liquidity check | quote | reuses the same fetch (sync never moves funds) |
| `Connector.withdrawAvailable` — zero-balance assert | quote | removed (`withdrawFromYieldVault` performs the identical clamp + assert) |
| `deposit` / `sponsorDeposit` / `startDraw` — `needsSync()` gates | quote each | removed (same threshold argument) |

Kept (load-bearing): the single sync/liquidity quote in `Pool.withdraw` (fair share pricing), and the clamp in `YieldVaultManagerWrapper.withdrawFromYieldVault` — upstream `FlowYieldVaults.YieldVault.withdraw` **reverts** rather than clamps when `amount > available`.

Also adds `get_pool_balance_safe.cdc`, a nil-safe balance read script.

## Validation

- **Mainnet fork replay** (emulator `--fork mainnet` at the failing block, real `update-contract` path):
  - Cadence update validator accepts both contracts in place — no storage migration, body-only changes
  - The originally stuck user's withdrawal **succeeds at ~8,200/9,999 units** (was: hard failure; −34%)
- **Test suite**: 452 passed, 0 failed (`make test`)

## Ship notes

- ⚠️ **The contract upgrade alone does not unblock users.** The frontend withdraw transaction must also drop its `prepare`-phase `getProjectedUserBalance` call (verified on the fork: old template + new contracts still exceeds the limit). Frontend release must ship with the deploy.
- Post-fix headroom is ~18%, and effectively less: `EVM.dryCall` hard-fails when the *remaining* budget is below the call's `gasLimit` argument, and upstream code passes oversized limits (15M gas for a `decimals()` read). Durable margin requires upstream fixes (FlowActions `SwapSource.withdrawAvailable` double quote; bridge `gasLimit` right-sizing), being filed separately.
- Rollout: testnet upgrade-in-place first (`839535ddeb5acf17`, mechanics + regression only — testnet pools use `MockYieldConnector`), then mainnet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)